### PR TITLE
extract used keywords for `Run Teardown Only Once`

### DIFF
--- a/utility.py
+++ b/utility.py
@@ -176,7 +176,7 @@ def extract_used_keywords(tokens):
     if tokens[0].lower() in ['run keyword', 'run keyword and continue on failure', 'run keyword and ignore error',
                              'run keyword and return', 'run keyword and return status', 'run keyword if all critical tests passed',
                              'run keyword if all tests passed', 'run keyword if any critical tests failed', 'run keyword if any tests failed',
-                             'run keyword if test failed', 'run keyword if test passed', 'run keyword if timeout occurred', 'run setup only once']:
+                             'run keyword if test failed', 'run keyword if test passed', 'run keyword if timeout occurred', 'run setup only once', 'run teardown only once']:
         ret.extend(extract_used_keywords(tokens[1:]))
     elif tokens[0].lower() in ['run keyword and return if', 'run keyword and expect error', 'run keyword if',
                                'run keyword unless', 'keyword should succeed within a period']:


### PR DESCRIPTION
Related PR: https://github.com/sunbirddcim/test_automation/pull/5600
_
Add `Run Teardown Only Once` to the list to get its used keyword.
```python
>>> extract_used_keywords(['Run Teardown Only Once', 'Action A', '${arg}'])
['Run Teardown Only Once', 'Action A']
```