### PR TITLE
Update rules to match update robot framework syntax

### DIFF
--- a/LibraryCheckRule/unused_keyword/case3_if_syntax/suite.txt
+++ b/LibraryCheckRule/unused_keyword/case3_if_syntax/suite.txt
@@ -1,0 +1,22 @@
+*** Test Cases ***
+Inline If Should Count Keyword Usage
+    ${condition}=    Set Variable    ${True}
+    IF    ${condition}    Used In Inline If
+    IF    ${condition}
+        Used In Block If
+    ELSE
+        Used In Else Block
+    END
+
+*** Keywords ***
+Used In Inline If
+    No Operation
+
+Used In Block If
+    No Operation
+
+Used In Else Block
+    No Operation
+
+Truly Unused
+    No Operation

--- a/LibraryCheckRule/unused_keyword/test.robot
+++ b/LibraryCheckRule/unused_keyword/test.robot
@@ -14,6 +14,9 @@ Case 1
 Case 2
     Check File    case2_bdd/suite.txt    W: 26, 0: Unused Keyword (UnusedKeyword)
 
+Case 3
+    Check File    case3_if_syntax/suite.txt    W: 21, 0: Unused Keyword (UnusedKeyword)
+
 *** Keywords ***
 Check File
     [Arguments]    ${file}    ${message}

--- a/utility.py
+++ b/utility.py
@@ -154,12 +154,30 @@ def extract_used_keywords(tokens):
     ['Run Keywords', 'Run Keyword If Test Passed', 'Action A', 'Run Keyword If Test Failed', 'Action B', 'Action C']
     >>> extract_used_keywords(['Run Keywords', 'Action A', '${arg}'])
     ['Run Keywords', 'Action A']
+
+    robot framework if syntax
+    >>> extract_used_keywords(['IF', '${cond}', 'Action A'])
+    ['Action A']
+    >>> extract_used_keywords(['IF', '${cond}', 'Action A', 'arg1', 'ELSE IF', '${cond2}', 'Action B', 'ELSE', 'Action C'])
+    ['Action A', 'Action B', 'Action C']
+    >>> extract_used_keywords(['IF', '${cond}'])
+    []
+    >>> extract_used_keywords(['END'])
+    []
     """
     ret = []
     if len(tokens) == 0 or tokens[0].startswith('#') or tokens[0] in ['[Documentation]', '[Arguments]', '[Tags]', '[Return]', '[Timeout]', ':FOR']:
         return ret
     if tokens[0].lower() in ['\\', '', '[teardown]', '[template]', '[setup]', 'given', 'when', 'then', 'and'] or re.match(r'[@$&]\{[^\}]+\}.*', tokens[0].lower()):
         return extract_used_keywords(tokens[1:])
+    if tokens[0].lower() == 'if':
+        indexes = [2] + [i for i, v in enumerate(tokens) if v.lower() in ['else if', 'else']]
+        for i in range(len(indexes)-1):
+            ret.extend(extract_used_keywords(tokens[indexes[i]:indexes[i+1]]))
+        ret.extend(extract_used_keywords(tokens[indexes[-1]:]))
+        return ret
+    if tokens[0].lower() == 'end':
+        return ret
     if tokens[:2] == ['...', 'ELSE'] or tokens[:2] == ['...', 'AND']:
         return extract_used_keywords(tokens[2:])
     if tokens[:2] == ['...', 'ELSE IF']:


### PR DESCRIPTION
Update rules to match syntax of updated robot framework.

`IF` can be used now instead of `Run Keyword If`. 

Old script gives false unused keywords errors for the keywords that used in new if statements.

Related PRs:
https://github.com/sunbirddcim/test_automation/pull/6826